### PR TITLE
Fix Ref and Memory leaks

### DIFF
--- a/src/chttp.cpp
+++ b/src/chttp.cpp
@@ -195,6 +195,7 @@ LUA_FUNCTION(CHTTP) {
 	if (!LUA->IsType(1, Lua::Type::Table)) {
 		LOG("No HTTPRequest table set.");
 		ret = false;
+		delete request;
 		goto exit;
 	}
 
@@ -216,6 +217,7 @@ LUA_FUNCTION(CHTTP) {
 	if (request->method == METHOD_NOSUPP) {
 		runFailedHandler(LUA, request->failed, "Unsupported request method: " + std::string(LUA->GetString(-1)));
 		ret = false;
+		delete request;
 		goto exit;
 	}
 	LUA->Pop();
@@ -227,6 +229,7 @@ LUA_FUNCTION(CHTTP) {
 	} else {
 		runFailedHandler(LUA, request->failed, "invalid url");
 		ret = false;
+		delete request;
 		goto exit;
 	}
 	LUA->Pop();

--- a/src/chttp.cpp
+++ b/src/chttp.cpp
@@ -15,14 +15,14 @@ std::string getUserAgent() {
 void runFailedHandler(Lua::ILuaBase *LUA, int successHandler, int failHandler, const std::string& reason) {
 	if(successHandler)
 		LUA->ReferenceFree(successHandler);
-	
+
 	if(!failHandler) {
 		return;
 	}
 
 	// Push fail handler to stack and free our ref
 	LUA->ReferencePush(failHandler);
-	LUA->ReferenceFree(failHandler);	
+	LUA->ReferenceFree(failHandler);
 
 	// Push the argument
 	LUA->PushString(reason.c_str());
@@ -34,7 +34,7 @@ void runFailedHandler(Lua::ILuaBase *LUA, int successHandler, int failHandler, c
 void runSuccessHandler(Lua::ILuaBase *LUA, int successHandler, int failHandler, const HTTPResponse *response) {
 	if(failHandler)
 		LUA->ReferenceFree(failHandler);
-	
+
 	if(!successHandler) {
 		return;
 	}

--- a/src/chttp.h
+++ b/src/chttp.h
@@ -4,5 +4,5 @@
 #define CHTTP_VERSION "1.3.2"
 
 bool processRequest(HTTPRequest *request);
-void runFailedHandler(GarrysMod::Lua::ILuaBase *LUA, int handler, const std::string& reason);
-void runSuccessHandler(GarrysMod::Lua::ILuaBase *LUA, int handler, HTTPResponse *response);
+void runFailedHandler(GarrysMod::Lua::ILuaBase *LUA, int successHandler, int failHandler, const std::string& reason);
+void runSuccessHandler(GarrysMod::Lua::ILuaBase *LUA, int successHandler, int failHandler, const HTTPResponse* response);

--- a/src/http.h
+++ b/src/http.h
@@ -10,11 +10,11 @@
 struct HTTPRequest {
 	// Handler for failed requests. args: (string) reason
 	// This is a reference to the function on the stack
-	int failed;
+	int failed = 0;
 
 	// Handler for successful requests. args: (number) code, (string) body, (table) headers
 	// This is a reference to the function on the stack
-	int success;
+	int success = 0;
 
 	// Request method (GET = 1, POST = 2, etc.)
 	// See method.{h,c} for details.

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -1,8 +1,12 @@
 #include <string>
+#include <cctype>
 #include "method.h"
 
 // Turns a string method into an int
-int methodFromString(const std::string& method) {
+int methodFromString(std::string method) {
+	for(auto& c : method) {
+		c = std::toupper(c);
+	}
 	if (method == "GET")
 		return METHOD_GET;
 	if (method == "POST")

--- a/src/method.h
+++ b/src/method.h
@@ -7,6 +7,6 @@
 #define METHOD_PATCH	6
 #define METHOD_OPTIONS	7
 
-int methodFromString(const std::string& method);
+int methodFromString(std::string method);
 std::string methodToString(int method);
 bool isLikePost(int method);

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -33,13 +33,13 @@ LUA_FUNCTION(threadingDoThink) {
 	while (!getFailQueue().empty()) {
 		FailedQueueData data = getFailQueue().front();
 		getFailQueue().pop();
-		runFailedHandler(LUA, data.handler, data.reason);
+		runFailedHandler(LUA, data.SuccessHandler, data.FailHandler, data.reason);
 	}
 
 	while (!getSuccessQueue().empty()) {
 		SuccessQueueData data = getSuccessQueue().front();
 		getSuccessQueue().pop();
-		runSuccessHandler(LUA, data.handler, data.response);
+		runSuccessHandler(LUA, data.SuccessHandler, data.FailHandler, data.response);
 		delete data.response;
 	}
 

--- a/src/threading.h
+++ b/src/threading.h
@@ -4,13 +4,15 @@
 
 // Data on the success queue
 struct SuccessQueueData {
-	int handler;
+	int SuccessHandler;
+	int FailHandler;
 	HTTPResponse *response;
 };
 
 // Data on the success queue
 struct FailedQueueData {
-	int handler;
+	int SuccessHandler;
+	int FailHandler;
 	std::string reason;
 };
 


### PR DESCRIPTION
Addresses the following
- Fixes reference leaks when calling the callbacks
- Fixes memory leak when calling CHTTP() with arguments that trigger an error
- Uppercases method string when comparing to allow for compatibility with invocations that send a lower case method (gmod http does this)

This doesn't address the issues with cleaning the queues at shutdown or thread running past module unload. To properly address these you need synchronization, so I'll let you do that or wait until you decide on a synchronization strategy. 