### PR TITLE
Add support for disabling redirects

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -255,7 +255,7 @@ resend:
     }
 
     curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirect);
-    if (redirect) {
+    if (!this->noredirect && redirect) {
         // Clear out saved headers and body
         response->headers.clear();
         response->body.clear();

--- a/src/HTTPRequest.h
+++ b/src/HTTPRequest.h
@@ -38,6 +38,10 @@ public:
     // Timeout for the request
     long timeout = 60;
 
+    // Optionally prevent redirects (30x)
+    // NOTE: Not in GMod HTTP
+    bool noredirect = false;
+
     HTTPRequest();
 
     std::string build_query_string();

--- a/src/chttp.cpp
+++ b/src/chttp.cpp
@@ -98,6 +98,13 @@ LUA_FUNCTION(CHTTP)
     }
     LUA->Pop();
 
+    // Fetch noredirect toggle
+    LUA->GetField(1, "noredirect");
+    if (LUA->IsType(-1, GarrysMod::Lua::Type::Bool)) {
+        request->noredirect = (bool)LUA->GetBool(-1);
+    }
+    LUA->Pop();
+
     if (!getenv("CHTTP_FORCE_HOOK")) {
         // If we are using timers, ensure that the timer is still present.
         // It might have gotten destroyed if there was an exception while running a callback.

--- a/tests/chttp.lua
+++ b/tests/chttp.lua
@@ -144,7 +144,7 @@ return {
                     success = function(code, body, headers)
                         expect(code).to.equal(307)
                         expect(body).to.equal("Redirecting...")
-                        expect(headers["Location"]).to.equal("/response_redirect_landing")
+                        expect(headers["Location"]).to.equal("http://127.0.0.1:5000/response_redirect_landing")
                         done()
                     end,
                     failed = function(err)

--- a/tests/chttp.lua
+++ b/tests/chttp.lua
@@ -137,10 +137,10 @@ return {
             name = "Redirect not followed",
             async = true,
             timeout = 1,
-            noredirect = true,
             func = function()
                 CHTTP({
                     url = "http://127.0.0.1:5000/response_redirect",
+                    noredirect = true,
                     success = function(code, body, headers)
                         expect(code).to.equal(307)
                         expect(body).to.equal("Redirecting...")

--- a/tests/chttp.lua
+++ b/tests/chttp.lua
@@ -114,5 +114,46 @@ return {
                 })
             end
         },
+        {
+            name = "Redirect followed",
+            async = true,
+            timeout = 1,
+            func = function()
+                CHTTP({
+                    url = "http://127.0.0.1:5000/response_redirect",
+                    success = function(code, body, headers)
+                        expect(code).to.equal(200)
+                        expect(body).to.equal("Redirected!")
+                        done()
+                    end,
+                    failed = function(err)
+                        error("HTTP request failed: " .. err)
+                        done()
+                    end
+                })
+            end
+        },
+        {
+            name = "Redirect not followed",
+            async = true,
+            timeout = 1,
+            noredirect = true,
+            func = function()
+                CHTTP({
+                    url = "http://127.0.0.1:5000/response_redirect",
+                    success = function(code, body, headers)
+                        expect(code).to.equal(307)
+                        expect(body).to.equal("Redirecting...")
+
+                        expect(headers["Location"] == "/response_redirect_landing").to.beTrue()
+                        done()
+                    end,
+                    failed = function(err)
+                        error("HTTP request failed: " .. err)
+                        done()
+                    end
+                })
+            end
+        },
     }
 }

--- a/tests/chttp.lua
+++ b/tests/chttp.lua
@@ -144,8 +144,7 @@ return {
                     success = function(code, body, headers)
                         expect(code).to.equal(307)
                         expect(body).to.equal("Redirecting...")
-
-                        expect(headers["Location"] == "/response_redirect_landing").to.beTrue()
+                        expect(headers["Location"]).to.equal("/response_redirect_landing")
                         done()
                     end,
                     failed = function(err)

--- a/tests/server.py
+++ b/tests/server.py
@@ -56,6 +56,19 @@ def response_multiple_warning():
         },
     )
 
+@app.route("/response_redirect", methods=["GET"])
+def response_redirect():
+    return (
+        b"Redirecting...",
+        307,
+        {
+            "Location": "/response_redirect_landing",
+        },
+    )
+
+@app.route("/response_redirect_landing", methods=["GET"])
+def response_redirect_landing():
+    return b"Redirected!", 200
 
 if __name__ == "__main__":
     app.run(debug=False, host="0.0.0.0")


### PR DESCRIPTION
I have a use case where what I need the HTTP call to do is "expand" the URL. Basically do the opposite of what a link-shortening service does, where we *want* the `Location` header. Normally in cURL, this would be controlled by `CURLOPT_FOLLOWLOCATION`, but I didn't want to fiddle with your existing implementation too much.

What I've added is a per-HTTPRequest boolean called `noredirect`. It's `false` by default (follow redirects).

Also for some reason I can't get the new tests to work, but the changes *do* work on a real GMod server, at least with linux64. I'm probably just missing something. If I figure that out, I'll update the PR.